### PR TITLE
Feature/frontend/navigate to loginpage

### DIFF
--- a/frontend/src/components/diff/WelcomeScreen.tsx
+++ b/frontend/src/components/diff/WelcomeScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Typography, IconButton,  Grid, Paper, Drawer, Switch, ThemeProvider } from '@mui/material';
-import { Info,  Close, CameraAlt, AddLocation, BarChart, ArrowBack, NearMe, Home } from '@mui/icons-material';
+import { Info,  Close, CameraAlt, AddLocation, BarChart, ArrowBack, NearMe, Home, ManageAccounts } from '@mui/icons-material';
 import { useNavigate } from 'react-router-dom';
 import HorizontalWheel from './HorizontalWheel';
 import { lightTheme, darkTheme } from '../../theme';
@@ -56,6 +56,10 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ username }) => {
   const navigateToAnalytics = () =>
   {
     navigate('/analytics');
+  };
+
+  const navigateToLoginpage = () => {
+    navigate('/login');
   };
 
   const handleThemeToggle = () => {
@@ -322,6 +326,17 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ username }) => {
               the location icon to add new locations, and the chart icon to view analytics. Toggle the switch in the top-right corner to change between light and dark themes.
             </Typography>
           </Box>
+
+          <Box>
+          <Box onClick={navigateToLoginpage} sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+            <ManageAccounts/>
+          </Box>
+
+          <Typography>
+            Login Info
+          </Typography>
+          </Box>
+          
         </Drawer>
       </Box>
     </ThemeProvider>

--- a/frontend/src/components/diff/WelcomeScreen.tsx
+++ b/frontend/src/components/diff/WelcomeScreen.tsx
@@ -327,14 +327,16 @@ const WelcomeScreen: React.FC<WelcomeScreenProps> = ({ username }) => {
             </Typography>
           </Box>
 
-          <Box>
-          <Box onClick={navigateToLoginpage} sx={{display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
+          
+          <Box onClick={navigateToLoginpage}  bgcolor={'grey'} sx={{width: 180,
+          height: 30,display: 'flex', px: 3, justifyContent: 'space-between',py:3  , alignItems: 'center'}}>
             <ManageAccounts/>
-          </Box>
-
-          <Typography>
-            Login Info
-          </Typography>
+            
+            <Box>
+            <Typography>
+              Login Info
+            </Typography>
+            </Box>
           </Box>
           
         </Drawer>


### PR DESCRIPTION
## 達成事項
loginpageにinfo drawerから遷移できるようにしました．デザインは簡素ですが，使う分には不自由ありません．
## 改善点
loginpageに遷移後，アカウント登録もしくはログインの操作を行わないとwelcomepageに戻れません．
## 改善点を改善するうえでの問題点
### no.1
loginpageに戻るボタンを設置しようとすると，一番最初にloginpageにアクセスするときにも画面に戻るボタンが表示されそうで違和感がありそう．
## 解決策
### no.1
loginpageに遷移後元々いたページに戻れるように戻るボタンを設置する．
### no.1.2
loginpageとは別にアカウント情報ページを作り，そちらに遷移する．
追加でログアウトボタンを設置する．